### PR TITLE
fixed inclusion of the management command package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name='django-exchange',
-    packages=['exchange'],
-    version='0.0.3',
+    packages=find_packages(),
+    version='0.0.4',
     description='currency, exchange rates and conversions support for django',
     author='Metglobal',
     author_email='kadir.pekel@metglobal.com',


### PR DESCRIPTION
find_packages() will find the management package and include it, otherwise all distributions will be missing the management command update_exchange_rates.  More info here: http://pythonhosted.org/distribute/setuptools.html#using-find-packages

Also incremented the version number so it can be resubmitted.
