### PR TITLE
Increase rate decimal places

### DIFF
--- a/exchange/models.py
+++ b/exchange/models.py
@@ -22,7 +22,7 @@ class ExchangeRate(models.Model):
     """Model to persist exchange rates between currencies"""
     source = models.ForeignKey('exchange.Currency', related_name='rates')
     target = models.ForeignKey('exchange.Currency')
-    rate = models.DecimalField(max_digits=12, decimal_places=2)
+    rate = models.DecimalField(max_digits=12, decimal_places=6)
 
     objects = ExchangeRateManager()
 


### PR DESCRIPTION
This seems the max number of decimal places that openexchangerates returns. Maybe South migrations or similar would be useful to manage schema changes?

Related: the openexchangerates Python library seems to convert the JSON value to a float, so accuracy may be lost in its conversion back to a decimal here.
