### PR TITLE
Python 3 compatibility.

### DIFF
--- a/exchange/adapters/__init__.py
+++ b/exchange/adapters/__init__.py
@@ -41,6 +41,7 @@ class BaseAdapter(object):
                     for d in existing}
         usd_exchange_rates = dict(self.get_exchangerates('USD'))
 
+        currencies_on_db = list(Currency.objects.all())
         updates = []
         inserts = []
         for source in currencies_on_db:

--- a/exchange/adapters/openexchangerates.py
+++ b/exchange/adapters/openexchangerates.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import logging
-from openexchangerates import OpenExchangeRatesClient
+from pyoxr import OXRClient
 
 from django.conf import settings
 
@@ -19,11 +19,10 @@ class OpenExchangeRatesAdapter(BaseAdapter):
     API_KEY_SETTINGS_KEY = 'OPENEXCHANGERATES_API_KEY'
 
     def __init__(self):
-        self.client = OpenExchangeRatesClient(
-            getattr(settings, self.API_KEY_SETTINGS_KEY))
+        self.client = OXRClient(app_id=getattr(settings, self.API_KEY_SETTINGS_KEY))
 
     def get_currencies(self):
-        return self.client.currencies().items()
+        return OXRClient.get_currencies(api=self.client).items()
 
     def get_exchangerates(self, base):
-        return self.client.latest(base)['rates'].items()
+        return OXRClient.get_latest(base, api=self.client)['rates'].items()

--- a/exchange/adapters/tests/test_openexchangerates.py
+++ b/exchange/adapters/tests/test_openexchangerates.py
@@ -1,5 +1,5 @@
 try:
-    from unittest import patch
+    from unittest.mock import patch
 except ImportError:
     from mock import patch
 

--- a/exchange/admin.py
+++ b/exchange/admin.py
@@ -1,5 +1,9 @@
+from __future__ import absolute_import
+
 from django.contrib import admin
-from models import Currency, ExchangeRate
+
+from .models import Currency, ExchangeRate
+
 
 class CurrencyAdmin(admin.ModelAdmin):
     search_fields = ('code',)

--- a/exchange/conversion.py
+++ b/exchange/conversion.py
@@ -1,5 +1,4 @@
 from collections import namedtuple
-from operator import itemgetter
 from datetime import timedelta
 
 from django.conf import settings
@@ -39,7 +38,7 @@ def convert_values(args_list):
 
     :return: map of converted values
     """
-    rate_map = get_rates(map(itemgetter(1, 2), args_list))
+    rate_map = get_rates((arg[1], arg[2]) for arg in args_list)
     value_map = {}
     for value, source, target in args_list:
         args = (value, source, target)
@@ -64,8 +63,8 @@ def get_rates(currencies):
                 targets.append(target)
     else:
         rate_map = {c: None for c in currencies}
-        sources = map(itemgetter(0), currencies)
-        targets = map(itemgetter(1), currencies)
+        sources = [source for source, _ in currencies]
+        targets = [target for _, target in currencies]
 
     rates = ExchangeRate.objects.filter(
         source__code__in=sources,

--- a/exchange/management/commands/update_rates.py
+++ b/exchange/management/commands/update_rates.py
@@ -11,5 +11,5 @@ class Command(BaseCommand):
 
         try:
             update_rates()
-        except Exception, e:
+        except Exception as e:
             raise CommandError(e)

--- a/exchange/models.py
+++ b/exchange/models.py
@@ -1,8 +1,13 @@
+from __future__ import unicode_literals
+
 from django.db import models
+from django.utils.six import python_2_unicode_compatible
+
 from exchange.managers import ExchangeRateManager
 from exchange.iso_4217 import code_list
 
 
+@python_2_unicode_compatible
 class Currency(models.Model):
     """Model holds a currency information for a nationality"""
     code = models.CharField(max_length=3, unique=True)
@@ -11,13 +16,14 @@ class Currency(models.Model):
     class Meta:
         verbose_name_plural = 'currencies'
 
-    def __unicode__(self):
+    def __str__(self):
         return self.code
 
     def get_numeric_code(self):
         return code_list[self.code]  # Let it raise an exception
 
 
+@python_2_unicode_compatible
 class ExchangeRate(models.Model):
     """Model to persist exchange rates between currencies"""
     source = models.ForeignKey('exchange.Currency', related_name='rates')
@@ -26,5 +32,5 @@ class ExchangeRate(models.Model):
 
     objects = ExchangeRateManager()
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s / %s = %s' % (self.source, self.target, self.rate)

--- a/exchange/tests.py
+++ b/exchange/tests.py
@@ -1,5 +1,9 @@
 import unittest
-from mock import patch
+
+try:
+    from unittest import patch
+except ImportError:
+    from mock import patch
 
 
 class TestConversion(unittest.TestCase):

--- a/exchange/tests.py
+++ b/exchange/tests.py
@@ -1,7 +1,7 @@
 import unittest
 
 try:
-    from unittest import patch
+    from unittest.mock import patch
 except ImportError:
     from mock import patch
 

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Internet :: WWW/HTTP',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=[
-        'openexchangerates'
+        'pyoxr'
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This PR updates the code to be python3-compatible.

Steps taken in order to achieve that:
1. Replaced `openexchangerates` with `pyoxr` as the former is python2-only and does not seem to be actively maintained.
2. Importing `patch` in tests from the correct place, depending on the python version running.
3. Updated models to use the django's `python2_unicode_compatbile` decorator and `__str__` instead of `__unicode__`.
4. Other minor style changes.

I ran the tests against python 2.7.13 and 3.6.2, but the code does not use any 3.x- specific constructs, so it should run just fine on 2.7+.